### PR TITLE
fix: 修复了事件发射的值，确保正确传递 `values.value` 而不是 `values`

### DIFF
--- a/src/components/mars-ui/mars-input-group/index.vue
+++ b/src/components/mars-ui/mars-input-group/index.vue
@@ -21,8 +21,8 @@ watchEffect(() => {
 const emits = defineEmits(["update:value", "change"])
 
 function itemChange(v, i) {
-  emits("update:value", values)
-  emits("change", values)
+  emits("update:value", values.value)
+  emits("change", values.value)
 }
 </script>
 <script lang="ts">


### PR DESCRIPTION
修复eslint报错:

![image](https://github.com/user-attachments/assets/21b2ce31-75e8-4585-8f30-249b4f890635)
